### PR TITLE
added default to from in ConvertGroup to Default

### DIFF
--- a/src/main/java/javax/validation/groups/ConvertGroup.java
+++ b/src/main/java/javax/validation/groups/ConvertGroup.java
@@ -42,7 +42,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Documented
 public @interface ConvertGroup {
 
-	Class<?> from();
+	Class<?> from() default Default.class;
 
 	Class<?> to();
 

--- a/src/main/java/javax/validation/groups/ConvertGroup.java
+++ b/src/main/java/javax/validation/groups/ConvertGroup.java
@@ -17,9 +17,7 @@
 package javax.validation.groups;
 
 import javax.validation.Valid;
-import java.lang.annotation.Documented;
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 import static java.lang.annotation.ElementType.CONSTRUCTOR;
 import static java.lang.annotation.ElementType.FIELD;
@@ -42,9 +40,15 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Documented
 public @interface ConvertGroup {
 
+	/**
+	 * Specifies from which group to convert.
+	 */
 	Class<?> from() default Default.class;
 
-	Class<?> to();
+	/**
+	 * Specifies to which group to convert.
+	 */
+	Class<?> to() default Default.class;
 
 	/**
 	 * Defines several {@link ConvertGroup} annotations


### PR DESCRIPTION
As per comments in [BVAL-493](https://hibernate.atlassian.net/browse/BVAL-493), I've added default to ConvertGroup - Default.

For use cases where group conversion is done from Default this change will simplify code:

`@ConvertGroup(from = Default.class, to = SecondLevelCheck.class)`

can be changed to 

`@ConvertGroup(to = SecondLevelCheck.class)`.
