### PR TITLE
BVAL-486 Directly instantiating given validation provider type in byP…

### DIFF
--- a/src/test/java/javax/validation/NonRegisteredValidationProvider.java
+++ b/src/test/java/javax/validation/NonRegisteredValidationProvider.java
@@ -1,0 +1,116 @@
+/*
+* JBoss, Home of Professional Open Source
+* Copyright 2016, Red Hat, Inc. and/or its affiliates, and individual contributors
+* by the @authors tag. See the copyright.txt in the distribution for a
+* full listing of individual contributors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package javax.validation;
+
+import java.io.InputStream;
+
+import javax.validation.NonRegisteredValidationProvider.NonRegisteredConfiguration;
+import javax.validation.spi.BootstrapState;
+import javax.validation.spi.ConfigurationState;
+import javax.validation.spi.ValidationProvider;
+
+/**
+ * A validation provide which is not registered with a service file and thus cannot be used with the default provider
+ * resolver.
+ *
+ * @author Gunnar Morling
+ */
+public class NonRegisteredValidationProvider implements ValidationProvider<NonRegisteredConfiguration> {
+
+	@Override
+	public NonRegisteredConfiguration createSpecializedConfiguration(BootstrapState state) {
+		return new NonRegisteredConfiguration();
+	}
+
+	@Override
+	public NonRegisteredConfiguration createGenericConfiguration(BootstrapState state) {
+		return new NonRegisteredConfiguration();
+	}
+
+	@Override
+	public ValidatorFactory buildValidatorFactory(ConfigurationState configurationState) {
+		return null;
+	}
+
+	public static class NonRegisteredConfiguration implements Configuration<NonRegisteredConfiguration> {
+
+		@Override
+		public NonRegisteredConfiguration ignoreXmlConfiguration() {
+			throw new UnsupportedOperationException( "Not implemented" );
+		}
+
+		@Override
+		public NonRegisteredConfiguration messageInterpolator(MessageInterpolator interpolator) {
+			throw new UnsupportedOperationException( "Not implemented" );
+		}
+
+		@Override
+		public NonRegisteredConfiguration traversableResolver(TraversableResolver resolver) {
+			throw new UnsupportedOperationException( "Not implemented" );
+		}
+
+		@Override
+		public NonRegisteredConfiguration constraintValidatorFactory(ConstraintValidatorFactory constraintValidatorFactory) {
+			throw new UnsupportedOperationException( "Not implemented" );
+		}
+
+		@Override
+		public NonRegisteredConfiguration parameterNameProvider(ParameterNameProvider parameterNameProvider) {
+			throw new UnsupportedOperationException( "Not implemented" );
+		}
+
+		@Override
+		public NonRegisteredConfiguration addMapping(InputStream stream) {
+			throw new UnsupportedOperationException( "Not implemented" );
+		}
+
+		@Override
+		public NonRegisteredConfiguration addProperty(String name, String value) {
+			throw new UnsupportedOperationException( "Not implemented" );
+		}
+
+		@Override
+		public MessageInterpolator getDefaultMessageInterpolator() {
+			throw new UnsupportedOperationException( "Not implemented" );
+		}
+
+		@Override
+		public TraversableResolver getDefaultTraversableResolver() {
+			throw new UnsupportedOperationException( "Not implemented" );
+		}
+
+		@Override
+		public ConstraintValidatorFactory getDefaultConstraintValidatorFactory() {
+			throw new UnsupportedOperationException( "Not implemented" );
+		}
+
+		@Override
+		public ParameterNameProvider getDefaultParameterNameProvider() {
+			throw new UnsupportedOperationException( "Not implemented" );
+		}
+
+		@Override
+		public BootstrapConfiguration getBootstrapConfiguration() {
+			throw new UnsupportedOperationException( "Not implemented" );
+		}
+
+		@Override
+		public ValidatorFactory buildValidatorFactory() {
+			throw new UnsupportedOperationException( "Not implemented" );
+		}
+	}
+}

--- a/src/test/java/javax/validation/ValidationTest.java
+++ b/src/test/java/javax/validation/ValidationTest.java
@@ -17,6 +17,11 @@
 package javax.validation;
 
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
 import java.io.IOException;
 import java.lang.ref.SoftReference;
 import java.net.URL;
@@ -24,14 +29,11 @@ import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
+
+import javax.validation.NonRegisteredValidationProvider.NonRegisteredConfiguration;
 import javax.validation.spi.ValidationProvider;
 
 import org.testng.annotations.Test;
-
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 /**
  * @author Hardy Ferentschik
@@ -134,6 +136,14 @@ public class ValidationTest {
 		}
 	}
 
+	// BVAL-486
+	@Test
+	public void testByProviderDoesNotRequireRetrievalViaProviderResolver() {
+		NonRegisteredConfiguration configuration = Validation.byProvider( NonRegisteredValidationProvider.class )
+				.configure();
+		assertNotNull( configuration );
+	}
+
 	private int countInMemoryProviders() {
 		int count = 0;
 		// we cannot access Validation.DefaultValidationProviderResolver#providersPerClassloader, so we have to
@@ -157,7 +167,7 @@ public class ValidationTest {
 
 		@Override
 		public Enumeration<URL> getResources(String name) throws IOException {
-			CustomEnumeration<URL> customEnumeration = new CustomEnumeration<URL>();
+			CustomEnumeration<URL> customEnumeration = new CustomEnumeration<>();
 
 			if ( SERVICES_FILE.equals( name ) && serviceFileSuffixes != null ) {
 				for ( String suffix : serviceFileSuffixes ) {
@@ -172,7 +182,7 @@ public class ValidationTest {
 	}
 
 	private static class CustomEnumeration<E> implements Enumeration<E> {
-		private final List<E> enumList = new ArrayList<E>();
+		private final List<E> enumList = new ArrayList<>();
 		int currentIndex = 0;
 
 		public void addElements(Enumeration<E> enumeration) {


### PR DESCRIPTION
…rovider() if no provider resolver has been given

https://hibernate.atlassian.net/browse/BVAL-486

I think the API is a bit flawed in the sense that `providerResolver()` should not be exposed once `byProvider()` has been called. Of course we cannot change that. So I instantiate the provider type directly now if no resolver has been given. If a provider and provider resolver has been given, the instantiation is done through the latter for the sake of compatability, though I don't think passing both is useful really.