### PR TITLE
BVAL-496 Improved java.time support

### DIFF
--- a/src/main/java/javax/validation/BootstrapConfiguration.java
+++ b/src/main/java/javax/validation/BootstrapConfiguration.java
@@ -23,6 +23,7 @@ import javax.validation.spi.ValidationProvider;
  * @author Emmanuel Bernard
  * @author Gunnar Morling
  * @author Hardy Ferentschik
+ * @author Guillaume Smet
  * @since 1.1
  */
 public interface BootstrapConfiguration {
@@ -66,6 +67,16 @@ public interface BootstrapConfiguration {
 	 * @return parameter name provider class name or {@code null}
 	 */
 	String getParameterNameProviderClassName();
+
+	/**
+	 * Class name of the {@link ClockProvider} implementation or
+	 * {@code null} if none is specified.
+	 *
+	 * @return clock provider class name or {@code null}
+	 *
+	 * @since 2.0
+	 */
+	String getClockProviderClassName();
 
 	/**
 	 * Returns a set of resource paths pointing to XML constraint mapping files.

--- a/src/main/java/javax/validation/ClockProvider.java
+++ b/src/main/java/javax/validation/ClockProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Bean Validation API
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package javax.validation;
+
+import java.time.Clock;
+
+/**
+ * Contract for obtaining the {@link Clock} used as the reference for {@code now} when validating the {@code @Future}
+ * and {@code @Past} constraints.
+ * <p>
+ * The default implementation will return the current system time. Plugging in custom implementations may be useful for
+ * instance in batch applications which need to run with a specific logical date, e.g. with yesterday's date when
+ * re-running a failed batch job execution.
+ * <p>
+ * Implementations must be safe for access from several threads at the same time.
+ *
+ * @author Gunnar Morling
+ * @author Guillaume Smet
+ * @since 2.0
+ */
+public interface ClockProvider {
+
+	/**
+	 * Returns the clock which serves as the reference for {@code now}.
+	 *
+	 * @return the clock which serves as the reference for {@code now}; must not be {@code null}
+	 */
+	Clock getClock();
+}

--- a/src/main/java/javax/validation/Configuration.java
+++ b/src/main/java/javax/validation/Configuration.java
@@ -46,6 +46,7 @@ import javax.validation.spi.ValidationProvider;
  * @author Emmanuel Bernard
  * @author Gunnar Morling
  * @author Hardy Ferentschik
+ * @author Guillaume Smet
  */
 public interface Configuration<T extends Configuration<T>> {
 
@@ -110,6 +111,20 @@ public interface Configuration<T extends Configuration<T>> {
 	 * @since 1.1
 	 */
 	T parameterNameProvider(ParameterNameProvider parameterNameProvider);
+
+	/**
+	 * Defines the clock provider. Has priority over the configuration
+	 * based provider.
+	 * <p>
+	 * If {@code null} is passed, the default clock provider is used
+	 * (defined in XML or the specification default).
+	 *
+	 * @param clockProvider clock provider implementation
+	 * @return {@code this} following the chaining method pattern.
+	 *
+	 * @since 2.0
+	 */
+	T clockProvider(ClockProvider clockProvider);
 
 	/**
 	 * Add a stream describing constraint mapping in the Bean Validation XML
@@ -223,6 +238,20 @@ public interface Configuration<T extends Configuration<T>> {
 	 * @since 1.1
 	 */
 	ParameterNameProvider getDefaultParameterNameProvider();
+
+	/**
+	 * Returns an implementation of the {@link ClockProvider}
+	 * interface following the default {@code ClockProvider}
+	 * defined in the specification:
+	 *
+	 * XXX BVAL-496 paste definition of the specification
+	 *
+	 * @return default {@code ClockProvider} implementation compliant with
+	 *         the specification
+	 *
+	 * @since 2.0
+	 */
+	ClockProvider getDefaultClockProvider();
 
 	/**
 	 * Returns configuration information stored in the {@code META-INF/validation.xml} file.

--- a/src/main/java/javax/validation/ConstraintValidatorContext.java
+++ b/src/main/java/javax/validation/ConstraintValidatorContext.java
@@ -6,6 +6,8 @@
  */
 package javax.validation;
 
+import java.time.Clock;
+
 /**
  * Provides contextual data and operation when applying a given constraint validator.
  *
@@ -13,6 +15,7 @@ package javax.validation;
  * of if the default {@code ConstraintViolation} is disabled, a custom one).
  *
  * @author Emmanuel Bernard
+ * @author Guillaume Smet
  */
 public interface ConstraintValidatorContext {
 
@@ -29,6 +32,19 @@ public interface ConstraintValidatorContext {
 	 * @return the current un-interpolated default message
 	 */
 	String getDefaultConstraintMessageTemplate();
+
+
+	/**
+	 * Returns the provider for obtaining the current time in the form of a {@link Clock}, e.g. when validating the
+	 * {@code Future} and {@code Past} constraints.
+	 *
+	 * @return the provider for obtaining the current time, never {@code null}. If no specific provider has been
+	 * configured during bootstrap, a default implementation using the current system time and the current default time
+	 * zone as returned by {@link Clock#systemDefaultZone()} will be returned.
+	 *
+	 * @since 2.0
+	 */
+	ClockProvider getClockProvider();
 
 	/**
 	 * Returns a constraint violation builder building a violation report

--- a/src/main/java/javax/validation/ValidatorContext.java
+++ b/src/main/java/javax/validation/ValidatorContext.java
@@ -18,6 +18,7 @@ package javax.validation;
  *
  * @author Emmanuel Bernard
  * @author Gunnar Morling
+ * @author Guillaume Smet
  */
 public interface ValidatorContext {
 
@@ -69,6 +70,18 @@ public interface ValidatorContext {
 	 * @since 1.1
 	 */
 	ValidatorContext parameterNameProvider(ParameterNameProvider parameterNameProvider);
+
+	/**
+	 * Defines the {@link ClockProvider} implementation used by the {@link Validator}.
+	 * If not set or if {@code null} is passed as a parameter,
+	 * the clock provider of the {@link ValidatorFactory} is used.
+	 *
+	 * @param clockProvider {@code ClockProvider} implementation
+	 * @return self following the chaining method pattern
+	 *
+	 * @since 2.0
+	 */
+	ValidatorContext clockProvider(ClockProvider clockProvider);
 
 	/**
 	 * Returns an initialized {@link Validator} instance respecting the defined state.

--- a/src/main/java/javax/validation/ValidatorFactory.java
+++ b/src/main/java/javax/validation/ValidatorFactory.java
@@ -14,6 +14,7 @@ package javax.validation;
  * @author Emmanuel Bernard
  * @author Gunnar Morling
  * @author Hardy Ferentschik
+ * @author Guillaume Smet
  */
 public interface ValidatorFactory extends AutoCloseable {
 
@@ -74,6 +75,17 @@ public interface ValidatorFactory extends AutoCloseable {
 	 * @since 1.1
 	 */
 	ParameterNameProvider getParameterNameProvider();
+
+	/**
+	 * Returns the {@link ClockProvider} instance configured at
+	 * initialization time for the {@code ValidatorFactory}.
+	 * This is the instance used by #getValidator().
+	 *
+	 * @return {@code ClockProvider} instance
+	 *
+	 * @since 2.0
+	 */
+	ClockProvider getClockProvider();
 
 	/**
 	 * Returns an instance of the specified type allowing access to

--- a/src/main/java/javax/validation/constraints/Future.java
+++ b/src/main/java/javax/validation/constraints/Future.java
@@ -27,12 +27,26 @@ import javax.validation.constraints.Future.List;
  * The annotated element must be a date in the future.
  * Now is defined as the current time according to the virtual machine
  * The calendar used if the compared type is of type {@code Calendar}
- * is the calendar based on the current timezone and the current locale.
+ * is the calendar based on the current time zone and the current locale.
  * <p>
  * Supported types are:
  * <ul>
  *     <li>{@code java.util.Date}</li>
  *     <li>{@code java.util.Calendar}</li>
+ *     <li>{@code java.time.Instant}</li>
+ *     <li>{@code java.time.LocalDate}</li>
+ *     <li>{@code java.time.LocalDateTime}</li>
+ *     <li>{@code java.time.LocalTime}</li>
+ *     <li>{@code java.time.MonthDay}</li>
+ *     <li>{@code java.time.OffsetDateTime}</li>
+ *     <li>{@code java.time.OffsetTime}</li>
+ *     <li>{@code java.time.Year}</li>
+ *     <li>{@code java.time.YearMonth}</li>
+ *     <li>{@code java.time.ZonedDateTime}</li>
+ *     <li>{@code java.time.chrono.HijrahDate}</li>
+ *     <li>{@code java.time.chrono.JapaneseDate}</li>
+ *     <li>{@code java.time.chrono.MinguoDate}</li>
+ *     <li>{@code java.time.chrono.ThaiBuddhistDate}</li>
  * </ul>
  * <p>
  * {@code null} elements are considered valid.

--- a/src/main/java/javax/validation/constraints/Future.java
+++ b/src/main/java/javax/validation/constraints/Future.java
@@ -18,6 +18,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+import java.time.Year;
 
 import javax.validation.Constraint;
 import javax.validation.Payload;
@@ -65,6 +66,14 @@ public @interface Future {
 	Class<?>[] groups() default { };
 
 	Class<? extends Payload>[] payload() default { };
+
+	/**
+	 * The notion of present here is defined relatively to the type on which the constraint is used. For instance, if
+	 * the constraint is on a {@link Year}, present would mean the whole current year.
+	 *
+	 * @return true if the present date should be considered valid
+	 */
+	boolean orPresent() default false;
 
 	/**
 	 * Defines several {@link Future} annotations on the same element.

--- a/src/main/java/javax/validation/constraints/Past.java
+++ b/src/main/java/javax/validation/constraints/Past.java
@@ -28,12 +28,26 @@ import javax.validation.constraints.Past.List;
  * Now is defined as the current time according to the virtual machine.
  * <p>
  * The calendar used if the compared type is of type {@code Calendar}
- * is the calendar based on the current timezone and the current locale.
+ * is the calendar based on the current time zone and the current locale.
  * <p>
  * Supported types are:
  * <ul>
  *     <li>{@code java.util.Date}</li>
  *     <li>{@code java.util.Calendar}</li>
+ *     <li>{@code java.time.Instant}</li>
+ *     <li>{@code java.time.LocalDate}</li>
+ *     <li>{@code java.time.LocalDateTime}</li>
+ *     <li>{@code java.time.LocalTime}</li>
+ *     <li>{@code java.time.MonthDay}</li>
+ *     <li>{@code java.time.OffsetDateTime}</li>
+ *     <li>{@code java.time.OffsetTime}</li>
+ *     <li>{@code java.time.Year}</li>
+ *     <li>{@code java.time.YearMonth}</li>
+ *     <li>{@code java.time.ZonedDateTime}</li>
+ *     <li>{@code java.time.chrono.HijrahDate}</li>
+ *     <li>{@code java.time.chrono.JapaneseDate}</li>
+ *     <li>{@code java.time.chrono.MinguoDate}</li>
+ *     <li>{@code java.time.chrono.ThaiBuddhistDate}</li>
  * </ul>
  * <p>
  * {@code null} elements are considered valid.

--- a/src/main/java/javax/validation/constraints/Past.java
+++ b/src/main/java/javax/validation/constraints/Past.java
@@ -18,6 +18,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+import java.time.Year;
 
 import javax.validation.Constraint;
 import javax.validation.Payload;
@@ -66,6 +67,14 @@ public @interface Past {
 	Class<?>[] groups() default { };
 
 	Class<? extends Payload>[] payload() default { };
+
+	/**
+	 * The notion of present here is defined relatively to the type on which the constraint is used. For instance, if
+	 * the constraint is on a {@link Year}, present would mean the whole current year.
+	 *
+	 * @return true if the present date should be considered valid
+	 */
+	boolean orPresent() default false;
 
 	/**
 	 * Defines several {@link Past} annotations on the same element.

--- a/src/main/java/javax/validation/spi/ConfigurationState.java
+++ b/src/main/java/javax/validation/spi/ConfigurationState.java
@@ -10,6 +10,7 @@ import java.io.InputStream;
 import java.util.Map;
 import java.util.Set;
 
+import javax.validation.ClockProvider;
 import javax.validation.Configuration;
 import javax.validation.ConstraintValidatorFactory;
 import javax.validation.MessageInterpolator;
@@ -28,6 +29,7 @@ import javax.validation.ValidatorFactory;
  * @author Emmanuel Bernard
  * @author Hardy Ferentschik
  * @author Gunnar Morling
+ * @author Guillaume Smet
  */
 public interface ConfigurationState {
 
@@ -128,6 +130,24 @@ public interface ConfigurationState {
 	 * @since 1.1
 	 */
 	ParameterNameProvider getParameterNameProvider();
+
+	/**
+	 * Returns the clock provider for this configuration.
+	 * <p>
+	 * {@link ClockProvider} is defined in the following decreasing priority:
+	 * <ul>
+	 *     <li>set via the {@link Configuration} programmatic API</li>
+	 *     <li>defined in {@code META-INF/validation.xml} provided that
+	 *     {@code ignoreXmlConfiguration} is {@code false}. In this case the instance
+	 *     is created via its no-arg constructor.</li>
+	 *     <li>{@code null} if undefined.</li>
+	 * </ul>
+	 *
+	 * @return clock provider instance or {@code null} if not defined
+	 *
+	 * @since 2.0
+	 */
+	ClockProvider getClockProvider();
 
 	/**
 	 * Returns a map of non type-safe custom properties.

--- a/src/test/java/javax/validation/BarValidationProvider.java
+++ b/src/test/java/javax/validation/BarValidationProvider.java
@@ -70,6 +70,11 @@ public class BarValidationProvider implements ValidationProvider<DummyConfigurat
 		}
 
 		@Override
+		public DummyConfiguration clockProvider(ClockProvider clockProvider) {
+			return null;
+		}
+
+		@Override
 		public DummyConfiguration addMapping(InputStream stream) {
 			return null;
 		}
@@ -96,6 +101,11 @@ public class BarValidationProvider implements ValidationProvider<DummyConfigurat
 
 		@Override
 		public ParameterNameProvider getDefaultParameterNameProvider() {
+			return null;
+		}
+
+		@Override
+		public ClockProvider getDefaultClockProvider() {
 			return null;
 		}
 
@@ -138,6 +148,11 @@ public class BarValidationProvider implements ValidationProvider<DummyConfigurat
 
 		@Override
 		public ParameterNameProvider getParameterNameProvider() {
+			return null;
+		}
+
+		@Override
+		public ClockProvider getClockProvider() {
 			return null;
 		}
 

--- a/src/test/java/javax/validation/FooValidationProvider.java
+++ b/src/test/java/javax/validation/FooValidationProvider.java
@@ -70,6 +70,11 @@ public class FooValidationProvider implements ValidationProvider<DummyConfigurat
 		}
 
 		@Override
+		public DummyConfiguration clockProvider(ClockProvider clockProvider) {
+			return null;
+		}
+
+		@Override
 		public DummyConfiguration addMapping(InputStream stream) {
 			return null;
 		}
@@ -96,6 +101,11 @@ public class FooValidationProvider implements ValidationProvider<DummyConfigurat
 
 		@Override
 		public ParameterNameProvider getDefaultParameterNameProvider() {
+			return null;
+		}
+
+		@Override
+		public ClockProvider getDefaultClockProvider() {
 			return null;
 		}
 
@@ -138,6 +148,11 @@ public class FooValidationProvider implements ValidationProvider<DummyConfigurat
 
 		@Override
 		public ParameterNameProvider getParameterNameProvider() {
+			return null;
+		}
+
+		@Override
+		public ClockProvider getClockProvider() {
 			return null;
 		}
 

--- a/src/test/java/javax/validation/NonRegisteredValidationProvider.java
+++ b/src/test/java/javax/validation/NonRegisteredValidationProvider.java
@@ -64,6 +64,11 @@ public class NonRegisteredValidationProvider implements ValidationProvider<NonRe
 		}
 
 		@Override
+		public NonRegisteredConfiguration clockProvider(ClockProvider clockProvider) {
+			throw new UnsupportedOperationException( "Not implemented" );
+		}
+
+		@Override
 		public NonRegisteredConfiguration addMapping(InputStream stream) {
 			throw new UnsupportedOperationException( "Not implemented" );
 		}
@@ -90,6 +95,11 @@ public class NonRegisteredValidationProvider implements ValidationProvider<NonRe
 
 		@Override
 		public ParameterNameProvider getDefaultParameterNameProvider() {
+			throw new UnsupportedOperationException( "Not implemented" );
+		}
+
+		@Override
+		public ClockProvider getDefaultClockProvider() {
 			throw new UnsupportedOperationException( "Not implemented" );
 		}
 


### PR DESCRIPTION
So this is the first part of a series of PRs related to java.time on BVAL, HV and BVTCK.

See beanvalidation/beanvalidation-tck#77 for the TCK changes.

See https://github.com/hibernate/hibernate-validator/pull/576 for the HV changes.

I hope it will be a good base for our future discussions.

This is based on the last version of https://github.com/sjmisterm/beanvalidation.org/blob/patch-1/proposals/BVAL-496.adoc .

A couple of differences though in the approach:
- I didn't use introspection to build the `now` object from the Clock and get the `compareTo` method. It would save some code but I don't think it's a good idea. I agree that it limits the support to officially supported types but I like it better this way. `AbstractJavaTimeValidator` makes it easy to add support for other types if required;
- I implemented all the default java.time types in this first round but I'll add optional support for threeten-extras as a proprietary extension in a followup-up patch if we decide to keep this approach;
- I named the `nowIsValid` option `orPresent` leading to having something like `@Past(orPresent = true)` which does not look too bad.

As for discussing it:
- remarks on the general approach should be discussed here so that they are centralized;
- comments on a specific PR should be added to the PR.