### PR TITLE
BVAL-455, BVAL-460, BVAL-496 Updating XML schemas:

### DIFF
--- a/src/main/xsd/validation-configuration-2.0.xsd
+++ b/src/main/xsd/validation-configuration-2.0.xsd
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Bean Validation API
+  ~
+  ~ License: Apache License, Version 2.0
+  ~ See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+  -->
+<xs:schema attributeFormDefault="unqualified"
+           elementFormDefault="qualified"
+           targetNamespace="http://xmlns.jcp.org/xml/ns/validation/configuration"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:config="http://xmlns.jcp.org/xml/ns/validation/configuration"
+           version="2.0">
+
+    <xs:annotation>
+        <xs:documentation><![CDATA[
+            This is the XML Schema for the Bean Validation configuration file.
+            The configuration file must be named "META-INF/validation.xml".
+
+            Bean Validation configuration files must indicate the Bean Validation
+            XML schema by using the validation namespace:
+
+            http://xmlns.jcp.org/xml/ns/validation/configuration
+
+            and indicate the version of the schema by using the version attribute
+            as shown below:
+
+            <validation-config
+                xmlns="http://xmlns.jcp.org/xml/ns/validation/configuration"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="
+                    http://xmlns.jcp.org/xml/ns/validation/configuration
+                    validation-configuration-2.0.xsd"
+                version="2.0">
+                [...]
+            </validation-config>
+        ]]>
+        </xs:documentation>
+    </xs:annotation>
+
+    <xs:element name="validation-config" type="config:validation-configType"/>
+    <xs:complexType name="validation-configType">
+        <xs:sequence>
+            <xs:element type="xs:string" name="default-provider" minOccurs="0"/>
+            <xs:element type="xs:string" name="message-interpolator" minOccurs="0"/>
+            <xs:element type="xs:string" name="traversable-resolver" minOccurs="0"/>
+            <xs:element type="xs:string" name="constraint-validator-factory" minOccurs="0"/>
+            <xs:element type="xs:string" name="parameter-name-provider" minOccurs="0"/>
+            <xs:element type="xs:string" name="clock-provider" minOccurs="0"/>
+            <xs:element type="config:executable-validationType" name="executable-validation" minOccurs="0"/>
+            <xs:element type="xs:string" name="constraint-mapping" maxOccurs="unbounded" minOccurs="0"/>
+            <xs:element type="config:propertyType" name="property" maxOccurs="unbounded" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="version" type="config:versionType" fixed="2.0" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="executable-validationType">
+        <xs:sequence>
+            <xs:element type="config:default-validated-executable-typesType" name="default-validated-executable-types" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="enabled" use="optional" type="xs:boolean" default="true"/>
+    </xs:complexType>
+    <xs:complexType name="default-validated-executable-typesType">
+        <xs:sequence>
+            <xs:element name="executable-type" maxOccurs="unbounded" minOccurs="1">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="NONE"/>
+                        <xs:enumeration value="CONSTRUCTORS"/>
+                        <xs:enumeration value="NON_GETTER_METHODS"/>
+                        <xs:enumeration value="GETTER_METHODS"/>
+                        <xs:enumeration value="ALL"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="propertyType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="name" use="required" type="xs:string"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:simpleType name="versionType">
+        <xs:restriction base="xs:token">
+            <xs:pattern value="[0-9]+(\.[0-9]+)*" />
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>

--- a/src/main/xsd/validation-mapping-2.0.xsd
+++ b/src/main/xsd/validation-mapping-2.0.xsd
@@ -7,10 +7,10 @@
   -->
 <xs:schema attributeFormDefault="unqualified"
            elementFormDefault="qualified"
-           targetNamespace="http://jboss.org/xml/ns/javax/validation/mapping"
+           targetNamespace="http://xmlns.jcp.org/xml/ns/validation/mapping"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns:map="http://jboss.org/xml/ns/javax/validation/mapping"
-           version="1.2">
+           xmlns:map="http://xmlns.jcp.org/xml/ns/validation/mapping"
+           version="2.0">
 
     <xs:annotation>
         <xs:documentation><![CDATA[
@@ -19,18 +19,18 @@
             Bean Validation constraint mapping files must indicate the Bean Validation
             XML schema by using the constraint mapping namespace:
 
-            http://jboss.org/xml/ns/javax/validation/mapping
+            http://xmlns.jcp.org/xml/ns/validation/mapping
 
             and indicate the version of the schema by using the version attribute
             as shown below:
 
             <constraint-mappings
-                xmlns="http://jboss.org/xml/ns/javax/validation/mapping"
+                xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 xsi:schemaLocation="
-                    http://jboss.org/xml/ns/javax/validation/mapping
-                    http://jboss.org/xml/ns/javax/validation/mapping/validation-mapping-1.2.xsd"
-                version="1.2">
+                    http://xmlns.jcp.org/xml/ns/validation/mapping
+                    validation-mapping-2.0.xsd"
+                version="2.0">
                 ...
             </constraint-mappings>
         ]]>
@@ -70,7 +70,7 @@
                         maxOccurs="unbounded"
                         minOccurs="0"/>
         </xs:sequence>
-        <xs:attribute name="version" type="map:versionType" fixed="1.2" use="required"/>
+        <xs:attribute name="version" type="map:versionType" fixed="2.0" use="required"/>
     </xs:complexType>
     <xs:simpleType name="versionType">
         <xs:restriction base="xs:token">


### PR DESCRIPTION
* Moving to version 2.0 (removing temporarily created 1.2 file)
* Moving to jcp.org namespace
* Adding notion of clock provider
* setting default value for "ignore-annotations"

https://hibernate.atlassian.net/browse/BVAL-455
https://hibernate.atlassian.net/browse/BVAL-460
https://hibernate.atlassian.net/browse/BVAL-496