### PR TITLE
BVAL-586 Support defining constraint on container element type in XML mapping

### DIFF
--- a/src/main/xsd/validation-mapping-2.0.xsd
+++ b/src/main/xsd/validation-mapping-2.0.xsd
@@ -109,6 +109,26 @@
         </xs:sequence>
         <xs:attribute type="xs:string" name="name" use="required"/>
     </xs:complexType>
+    <xs:complexType name="containerElementTypeType">
+        <xs:sequence>
+            <xs:element type="xs:string" name="valid" minOccurs="0" fixed=""/>
+            <xs:element type="map:constraintType"
+                        name="constraint"
+                        maxOccurs="unbounded"
+                        minOccurs="0"/>
+            <xs:element type="map:containerElementTypeType"
+                        name="containerElementType"
+                        maxOccurs="unbounded"
+                        minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="typeArgumentIndex" use="optional">
+            <xs:simpleType>
+                <xs:restriction base="xs:int">
+                    <xs:minInclusive value="0" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
     <xs:complexType name="classType">
         <xs:sequence>
             <xs:element type="map:groupSequenceType"
@@ -162,6 +182,10 @@
                         name="convert-group"
                         minOccurs="0"
                         maxOccurs="unbounded"/>
+            <xs:element type="map:containerElementTypeType"
+                        name="containerElementType"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
             <xs:element type="map:constraintType"
                         name="constraint"
                         minOccurs="0"
@@ -212,6 +236,10 @@
                         name="convert-group"
                         minOccurs="0"
                         maxOccurs="unbounded"/>
+            <xs:element type="map:containerElementTypeType"
+                        name="containerElementType"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
             <xs:element type="map:constraintType"
                         name="constraint"
                         minOccurs="0"
@@ -225,6 +253,10 @@
             <xs:element type="xs:string" name="valid" minOccurs="0" fixed=""/>
             <xs:element type="map:groupConversionType"
                         name="convert-group"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element type="map:containerElementTypeType"
+                        name="containerElementType"
                         minOccurs="0"
                         maxOccurs="unbounded"/>
             <xs:element type="map:constraintType"
@@ -255,6 +287,10 @@
             <xs:element type="xs:string" name="valid" minOccurs="0" fixed=""/>
             <xs:element type="map:groupConversionType"
                         name="convert-group"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element type="map:containerElementTypeType"
+                        name="containerElementType"
                         minOccurs="0"
                         maxOccurs="unbounded"/>
             <xs:element type="map:constraintType"


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/BVAL-586

For the following model:
```java
public class FishTank {
    public Map<String, List<Fish>> fishOfTheMonth;
}
```

To declare something similar to:
```java
public Map<String, List<@NotNull Fish>> fishOfTheMonth;
```

We would have:
```xml
    <bean class="my.package.FishTank" ignore-annotations="false">
        <field name="fishOfTheMonth">
            <containerElementType typeArgumentIndex="1">
                <containerElementType typeArgumentIndex="0">
                    <constraint annotation="javax.validation.constraints.NotNull" />
                </containerElementType>
            </containerElementType>
        </field>
    </bean>
```