### PR TITLE
BVAL-594 Extend metadata API with container element types metadata

### DIFF
--- a/src/main/java/javax/validation/metadata/BeanDescriptor.java
+++ b/src/main/java/javax/validation/metadata/BeanDescriptor.java
@@ -50,7 +50,7 @@ public interface BeanDescriptor extends ElementDescriptor {
 	 * Returns a set of property descriptors having at least one constraint defined
 	 * or marked as cascaded ({@link Valid}).
 	 * <p>
-	 * If not property matches, an empty set is returned.
+	 * If no property matches, an empty set is returned.
 	 * Properties of super types are considered.
 	 *
 	 * @return the set of {@link PropertyDescriptor}s for the constraint properties; if

--- a/src/main/java/javax/validation/metadata/ContainerDescriptor.java
+++ b/src/main/java/javax/validation/metadata/ContainerDescriptor.java
@@ -1,0 +1,35 @@
+package javax.validation.metadata;
+
+import java.util.Set;
+
+import javax.validation.Valid;
+
+/**
+ * Represents an element that might be a container, thus allowing container element constraints.
+ *
+ * @author Guillaume Smet
+ * @since 2.0
+ */
+public interface ContainerDescriptor {
+
+	/**
+	 * Returns the container element type descriptor for a given type argument.
+	 * <p>
+	 * Returns {@code null} if the container element type does not exist or has no constraint nor is marked as cascaded
+	 * (see {@link #getConstrainedContainerElementTypes()})
+	 *
+	 * @param typeArgumentIndex type argument index evaluated
+	 * @return the container element type descriptor
+	 */
+	ContainerElementTypeDescriptor getConstraintsForContainerElementType(int typeArgumentIndex);
+
+	/**
+	 * Returns a set of container element type descriptors having at least one constraint defined or marked as cascaded
+	 * ({@link Valid}).
+	 * <p>
+	 * If no container element type matches, an empty set is returned.
+	 *
+	 * @return the set of {@link ContainerElementTypeDescriptor}s
+	 */
+	Set<ContainerElementTypeDescriptor> getConstrainedContainerElementTypes();
+}

--- a/src/main/java/javax/validation/metadata/ContainerElementTypeDescriptor.java
+++ b/src/main/java/javax/validation/metadata/ContainerElementTypeDescriptor.java
@@ -1,0 +1,15 @@
+package javax.validation.metadata;
+
+/**
+ * Describes a validated container element type.
+ *
+ * @author Guillaume Smet
+ * @since 2.0
+ */
+public interface ContainerElementTypeDescriptor extends ElementDescriptor, CascadableDescriptor, ContainerDescriptor {
+
+	/**
+	 * @return the index of the type argument corresponding to this container element type
+	 */
+	Integer getTypeArgumentIndex();
+}

--- a/src/main/java/javax/validation/metadata/ParameterDescriptor.java
+++ b/src/main/java/javax/validation/metadata/ParameterDescriptor.java
@@ -12,7 +12,7 @@ package javax.validation.metadata;
  * @author Gunnar Morling
  * @since 1.1
  */
-public interface ParameterDescriptor extends ElementDescriptor, CascadableDescriptor {
+public interface ParameterDescriptor extends ElementDescriptor, CascadableDescriptor, ContainerDescriptor {
 
 	/**
 	 * Returns this parameter's index within the parameter array of the method

--- a/src/main/java/javax/validation/metadata/PropertyDescriptor.java
+++ b/src/main/java/javax/validation/metadata/PropertyDescriptor.java
@@ -14,7 +14,7 @@ package javax.validation.metadata;
  *
  * @author Emmanuel Bernard
  */
-public interface PropertyDescriptor extends ElementDescriptor, CascadableDescriptor {
+public interface PropertyDescriptor extends ElementDescriptor, CascadableDescriptor, ContainerDescriptor {
 
 	/**
 	 * Name of the property according to the Java Bean specification.

--- a/src/main/java/javax/validation/metadata/ReturnValueDescriptor.java
+++ b/src/main/java/javax/validation/metadata/ReturnValueDescriptor.java
@@ -12,5 +12,5 @@ package javax.validation.metadata;
  * @author Gunnar Morling
  * @since 1.1
  */
-public interface ReturnValueDescriptor extends ElementDescriptor, CascadableDescriptor {
+public interface ReturnValueDescriptor extends ElementDescriptor, CascadableDescriptor, ContainerDescriptor {
 }


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/BVAL-594

@gunnarmorling is this what you had in mind? Note that it's really far fetched from our internal model so we need some quite heavy data remodeling (I haven't finished this part yet).

If you have a better idea than `ContainerDescriptor`, it's welcome. The idea is more `containerable`.