### PR TITLE
BVAL-605 Avoid empty initialize() methods in spec examples

### DIFF
--- a/src/test/java/javax/validation/examples/ScriptAssertValidator.java
+++ b/src/test/java/javax/validation/examples/ScriptAssertValidator.java
@@ -16,10 +16,7 @@ import javax.validation.constraintvalidation.ValidationTarget;
  * @author Emmanuel Bernard <emmanuel@hibernate.org>
  */
 @SupportedValidationTarget( { ValidationTarget.ANNOTATED_ELEMENT, ValidationTarget.PARAMETERS } )
-public class ScriptAssertValidator implements ConstraintValidator<NotNull,Object[]> {
-	@Override
-	public void initialize(NotNull constraintAnnotation) {
-	}
+public class ScriptAssertValidator implements ConstraintValidator<NotNull, Object[]> {
 
 	@Override
 	public boolean isValid(Object[] value, ConstraintValidatorContext context) {


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/BVAL-605

Not sure this "example" is very useful to be honest.