### PR TITLE
BVAL-634 Defining empty default value for @OverridesAttribute#name() …

### DIFF
--- a/src/main/java/javax/validation/OverridesAttribute.java
+++ b/src/main/java/javax/validation/OverridesAttribute.java
@@ -40,7 +40,7 @@ public @interface OverridesAttribute {
 	 *
 	 * @return name of constraint attribute overridden
 	 */
-	String name();
+	String name() default "";
 
 	/**
 	 * The index of the targeted constraint declaration when using


### PR DESCRIPTION
…so it behaves as described in its docs and the spec